### PR TITLE
Dev docs: edits to removed estimatepriority RPC

### DIFF
--- a/_includes/devdoc/bitcoin-core/rpcs/rpcs/estimatepriority.md
+++ b/_includes/devdoc/bitcoin-core/rpcs/rpcs/estimatepriority.md
@@ -13,9 +13,9 @@ http://opensource.org/licenses/MIT.
 
 *Added in Bitcoin Core 0.10.0.*
 
-The `estimatepriority` RPC {{summary_estimatePriority}} (not to be confused with the `prioritisetransaction` RPC which will remain supported for adding fee deltas to transactions)
+The `estimatepriority` RPC {{summary_estimatePriority}} This should not to be confused with the `prioritisetransaction` RPC which will remain supported for adding fee deltas to transactions.
 
-{{WARNING}} `estimatepriority` has been [removed](https://github.com/bitcoin/bitcoin/commit/fe282acd7604b5265762b24e531bdf1ebb1f009b) and will no longer be available in the next major release (target v0.15.0).  Use the RPCs listed in the "See Also" subsection below instead.
+{{WARNING}} `estimatepriority` has been [removed](https://github.com/bitcoin/bitcoin/commit/fe282acd7604b5265762b24e531bdf1ebb1f009b) and will no longer be available in the next major release (planned for Bitcoin Core 0.15.0).  Use the RPC listed in the "See Also" subsection below instead.
 
 Transaction priority is relative to a transaction's byte size.
 


### PR DESCRIPTION
This makes a few minor edits to your branch:

- Changed the parenthetical to a sentence since it follows the period of a previous sentence
- Changed "target" to "planned for" since we auto-cross-reference "target" to https://bitcoin.org/en/glossary/nbits
- Changed "v0.15.0" to "Bitcoin Core 0.15.0" so we'll automatically link that when 0.15 is released.

Here's a preview:

![2017-05-12-13_53_58_719059445](https://cloud.githubusercontent.com/assets/61096/26010734/1b3678fe-371c-11e7-9bf4-88961ec50955.png)
